### PR TITLE
Add cacheSeconds which is preferred to maxAge

### DIFF
--- a/getRedirect.js
+++ b/getRedirect.js
@@ -38,7 +38,7 @@ const getStatus = checkSuites => {
   return matched.conclusion;
 };
 
-const OPTIONS = ["style", "logo", "label", "logoColor", "logoWidth", "link", "colorA", "colorB", "maxAge"];
+const OPTIONS = ["style", "logo", "label", "logoColor", "logoWidth", "link", "colorA", "colorB", "maxAge", "cacheSeconds"];
 
 const getQueryParams = options => OPTIONS.reduce((accum, key) => {
   const normal = options[key] || accum[key] || null;


### PR DESCRIPTION
 https://shields.io/category/dependencies

> ?cacheSeconds=3600	Set the HTTP cache lifetime (rules are applied to infer a default value on a per-badge basis, any values specified below the default will be ignored). The legacy name "maxAge" is also supported.