### PR TITLE
Add support for branches other than 'master'

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,13 @@ where `{owner}` and `{repo}` are replaced by the github username and the reposit
 https://wdp9fww0r9.execute-api.us-west-2.amazonaws.com/production/badge/CultureHQ/github-actions-badge
 ```
 
+Optionally a branch can be specified using the `{branch}` parameter.
+Without this parameter, it will use the `master` branch.
+
+```
+https://wdp9fww0r9.execute-api.us-west-2.amazonaws.com/production/badge/{owner}/{repo}/{branch}
+```
+
 The badge variants look like:
 
 * ![Error](https://img.shields.io/badge/GitHub_Actions-error-red.svg?logo=github&logoColor=white)

--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ where `{owner}` and `{repo}` are replaced by the github username and the reposit
 https://wdp9fww0r9.execute-api.us-west-2.amazonaws.com/production/badge/CultureHQ/github-actions-badge
 ```
 
-Optionally a branch can be specified using the `{branch}` parameter.
+Optionally a branch can be specified using the `branch` query parameter.
 Without this parameter, it will use the `master` branch.
 
 ```
-https://wdp9fww0r9.execute-api.us-west-2.amazonaws.com/production/badge/{owner}/{repo}/{branch}
+https://wdp9fww0r9.execute-api.us-west-2.amazonaws.com/production/badge/{owner}/{repo}?branch={branch}
 ```
 
 The badge variants look like:

--- a/getRedirect.js
+++ b/getRedirect.js
@@ -46,8 +46,8 @@ const makeRedirect = options => checkSuite => {
   };
 };
 
-const getRedirect = (owner, repo, options) => (
-  getCheckSuite(owner, repo).then(makeRedirect(options || {}))
+const getRedirect = (owner, repo, options, branch) => (
+  getCheckSuite(owner, repo, branch).then(makeRedirect(options || {}))
 );
 
 module.exports = getRedirect;

--- a/getRedirect.js
+++ b/getRedirect.js
@@ -16,6 +16,7 @@ const getQueryParams = options => OPTIONS.reduce((accum, key) => {
 }, { logo: "github", logoColor: "white" });
 
 const getQuery = options => {
+  delete options.branch
   const params = getQueryParams(options);
 
   return Object.keys(params).reduce((accum, key, index) => (

--- a/githubClient.js
+++ b/githubClient.js
@@ -42,12 +42,13 @@ const findCheckSuite = parsed => {
   return matched;
 };
 
-const getCheckSuite = (owner, repo) => (
-  makeRequest(`/repos/${owner}/${repo}/commits/master/check-suites`).then(findCheckSuite)
-);
+const getCheckSuite = (owner, repo, branch) => {
+  branch = branch || 'master'
+  return makeRequest(`/repos/${owner}/${repo}/commits/${branch}/check-suites`).then(findCheckSuite)
+};
 
-const getLatestRunURL = (owner, repo) => (
-  getCheckSuite(owner, repo)
+const getLatestRunURL = (owner, repo, branch) => (
+  getCheckSuite(owner, repo, branch)
     .then(checkSuite => makeRequest(checkSuite.check_runs_url))
     .then(response => ({
       url: response.check_runs[0].html_url,

--- a/handler.js
+++ b/handler.js
@@ -25,13 +25,13 @@ const handle = (event, context, callback) => {
     return process(getRedirect(event.pathParameters.owner,
                                event.pathParameters.repo,
                                event.queryStringParameters,
-                               event.pathParameters.branch), callback);
+                               event.queryStringParameters.branch), callback);
   }
 
   if (event.path.startsWith("/results")) {
     return process(getLatestRunURL(event.pathParameters.owner,
                                    event.pathParameters.repo,
-                                   event.pathParameters.branch), callback);
+                                   event.queryStringParameters.branch), callback);
   }
 
   callback(null, { statusCode: 404 });

--- a/handler.js
+++ b/handler.js
@@ -22,11 +22,16 @@ const process = (promise, callback) => (
 
 const handle = (event, context, callback) => {
   if (event.path.startsWith("/badge")) {
-    return process(getRedirect(event.pathParameters.owner, event.pathParameters.repo, event.queryStringParameters), callback);
+    return process(getRedirect(event.pathParameters.owner,
+                               event.pathParameters.repo,
+                               event.queryStringParameters,
+                               event.pathParameters.branch), callback);
   }
 
   if (event.path.startsWith("/results")) {
-    return process(getLatestRunURL(event.pathParameters.owner, event.pathParameters.repo), callback);
+    return process(getLatestRunURL(event.pathParameters.owner,
+                                   event.pathParameters.repo,
+                                   event.pathParameters.branch), callback);
   }
 
   callback(null, { statusCode: 404 });

--- a/server.js
+++ b/server.js
@@ -26,17 +26,17 @@ app.use((request, response, next) => {
   next();
 });
 
-app.get("/results/:owner/:repo/:branch*?", (request, response) => {
+app.get("/results/:owner/:repo", (request, response) => {
   process(getLatestRunURL(request.params.owner,
                           request.params.repo,
-                          request.params.branch), response);
+                          request.query.branch), response);
 });
 
-app.get("/:owner/:repo/:branch*?", (request, response) => {
+app.get("/:owner/:repo", (request, response) => {
   process(getRedirect(request.params.owner,
                       request.params.repo,
                       request.query,
-                      request.params.branch), response);
+                      request.query.branch), response);
 });
 
 app.listen(8080, () => console.log("Listening on port 8080..."));

--- a/server.js
+++ b/server.js
@@ -26,12 +26,17 @@ app.use((request, response, next) => {
   next();
 });
 
-app.get("/:owner/:repo", (request, response) => {
-  process(getRedirect(request.params.owner, request.params.repo, request.query), response);
+app.get("/results/:owner/:repo/:branch*?", (request, response) => {
+  process(getLatestRunURL(request.params.owner,
+                          request.params.repo,
+                          request.params.branch), response);
 });
 
-app.get("/results/:owner/:repo", (request, response) => {
-  process(getLatestRunURL(request.params.owner, request.params.repo), response);
+app.get("/:owner/:repo/:branch*?", (request, response) => {
+  process(getRedirect(request.params.owner,
+                      request.params.repo,
+                      request.query,
+                      request.params.branch), response);
 });
 
 app.listen(8080, () => console.log("Listening on port 8080..."));

--- a/serverless.yml
+++ b/serverless.yml
@@ -20,5 +20,11 @@ functions:
         path: badge/{owner}/{repo}
         method: get
     - http:
+        path: badge/{owner}/{repo}/{branch}
+        method: get
+    - http:
         path: results/{owner}/{repo}
+        method: get
+    - http:
+        path: results/{owner}/{repo}/{branch}
         method: get

--- a/serverless.yml
+++ b/serverless.yml
@@ -20,11 +20,5 @@ functions:
         path: badge/{owner}/{repo}
         method: get
     - http:
-        path: badge/{owner}/{repo}/{branch}
-        method: get
-    - http:
         path: results/{owner}/{repo}
-        method: get
-    - http:
-        path: results/{owner}/{repo}/{branch}
         method: get


### PR DESCRIPTION
Adds an optional parameter to both API endpoints to specify a branch.

This is useful for repositories with release candidate or testing branches
that may have separate continuous integration.