### PR TITLE
Added better colors

### DIFF
--- a/getRedirect.js
+++ b/getRedirect.js
@@ -25,9 +25,9 @@ const getQuery = options => {
 
 const STATUS_COLORS = {
   error: "red",
-  failure: "lightgrey",
+  failure: "critical",
   pending: "yellow",
-  success: "green",
+  success: "success",
   no_runs: "lightgrey"
 };
 


### PR DESCRIPTION
Changed the colors to use the standard "success" for green and red for error:

![color success](https://img.shields.io/badge/color-success-success.svg) ![color failure](https://img.shields.io/badge/color-failure-critical.svg)

```
![color success](https://img.shields.io/badge/color-success-success.svg)
![color failure](https://img.shields.io/badge/color-failure-critical.svg)
```