### PR TITLE
Add ability to read github token from environment

### DIFF
--- a/.env.yml.example
+++ b/.env.yml.example
@@ -1,0 +1,1 @@
+GITHUB_TOKEN: token-with-repo-access

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.serverless/
 /node_modules/
+.env.yml

--- a/README.md
+++ b/README.md
@@ -37,6 +37,15 @@ For instance, if you wanted to change the style to `flat-square`, you could pass
 [![Actions Status](https://wdp9fww0r9.execute-api.us-west-2.amazonaws.com/production/badge/{owner}/{repo}?style=flat-square)](https://wdp9fww0r9.execute-api.us-west-2.amazonaws.com/production/results/{owner}/{repo})
 ```
 
+## Status for private repo's
+
+In order for the lambda to get status from Github for private repos, you have to create
+a token with repo access and set that in `.env.yml`.
+
+```shell
+cp .env.yml.example .env.yml
+```
+
 ## Development
 
 To develop locally, install dependencies with `yarn`. Then you can run `yarn start` at the root of the repository to start a local server.

--- a/githubClient.js
+++ b/githubClient.js
@@ -2,17 +2,20 @@ const https = require("https");
 
 const makeRequest = path =>
   new Promise((resolve, reject) => {
-    const req = {
+    let req = {
       hostname: "api.github.com",
       port: 443,
       path,
       method: "GET",
       headers: {
         Accept: "application/vnd.github.antiope-preview+json",
-        // Authorization: "token TOKEN",
         "User-Agent": "node"
       }
     };
+
+    if (process.env.GITHUB_TOKEN) {
+      req.headers.Authorization = `token ${process.env.GITHUB_TOKEN}`;
+    }
 
     https.get(req, resp => {
       let data = "";

--- a/serverless.yml
+++ b/serverless.yml
@@ -15,6 +15,8 @@ package:
 functions:
   badge:
     handler: handler.handle
+    environment:
+      GITHUB_TOKEN: ${file(.env.yml):GITHUB_TOKEN}
     events:
       - http:
           path: badge/{owner}/{repo}


### PR DESCRIPTION
This is useful for working with private repo's and is based on the suggestion in https://github.com/CultureHQ/github-actions-badge/issues/8.

*Note*: If the `.env.yml` is not present, we get the following warning when we deploy as a lambda -

 A valid file to satisfy the declaration 'file(.env.yml):GITHUB_TOKEN' could not be found.