### PR TITLE
Bump nodejs runtime to 10 and use the options passed into serverless

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -2,15 +2,13 @@ service: github-actions-badge
 
 provider:
   name: aws
-  runtime: nodejs8.10
-  stage: production
-  region: us-west-2
+  runtime: nodejs10.x
+  stage: ${opt:stage, 'production'}
+  region: ${opt:region, 'us-west-2'}
 
 package:
   exclude:
-    - coverage/
     - server.js
-    - test/
 
 functions:
   badge:


### PR DESCRIPTION
AWS lambda now supports nodejs 10 - https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html.

Also use the options passed into serverless when deploying the lambda. For instance - `sls deploy -r eu-central-1`